### PR TITLE
Particles.vue: mark id prop as required and throw error if not present

### DIFF
--- a/src/components/Particles/Particles.vue
+++ b/src/components/Particles/Particles.vue
@@ -34,7 +34,7 @@
 
     @Component
     export default class Particles extends Vue {
-        @Prop() private id!: string;
+        @Prop({required: true}) private id!: string;
         @Prop() private clickEffect!: boolean;
         @Prop() private clickMode!: ClickMode;
         @Prop() private color!: string;
@@ -95,6 +95,9 @@
             clickEffect: boolean,
             clickMode: ClickMode
         ): void {
+            if(!this.id){
+                throw new Error("Prop 'id' is required!")
+            }
             tsParticles.load(this.id, {
                 fps_limit: 60,
                 interactivity: {


### PR DESCRIPTION
This prop is absolutely required for the component to work.
`required: true` throws a warning during development, but the component
can't function at all without the id, so an error being thrown makes sense.